### PR TITLE
Take the SLAAC address instead of a random IPv6 address

### DIFF
--- a/root/app/cloudflare-ddns.sh
+++ b/root/app/cloudflare-ddns.sh
@@ -156,7 +156,7 @@ while true; do
             ;;
         local:*)
             [[ ${CHECK_IPV4} == "true" ]] && newipv4=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet" {gsub(/\/.*$/, "", $2); print $2}' | head -1)
-            [[ ${CHECK_IPV6} == "true" ]] && newipv6=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet6" {gsub(/\/.*$/, "", $2); print $2}' | head -1)
+            [[ ${CHECK_IPV6} == "true" ]] && newipv6=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet6" && $7 == "noprefixroute" {gsub(/\/.*$/, "", $2); print $2 }' | head -1)
             ;;
     esac
     [[ ${CHECK_IPV4} == "true" ]] && logger "IPv4 detected by [${DETECTION_MODE}] is [${newipv4}]."


### PR DESCRIPTION
This solves the issue in a situation where there are only SLAAC addresses on the network and the system has multiple addresses. This is the main address, based on the prefix + the MAC address.

E.g.: 

```
$ ip addr show "eno1" 2>/dev/null | awk '$1 == "inet6" {gsub(/\/.*$/, "", $2); print $2}' # omitted the head -1
redacted:9ef2:3cb8:5c06:44ff
redacted:b369:b1af:cfc:b44c
redacted:ce87:3f4f:1711:2625
redacted:aa5d:35c6:44b:d528
redacted:3e53:121e:b9e6:1f2e
redacted:1eea:2f0a:40a5:7a3d
redacted:46ae:9b45:f223:98c8
redacted:21f:c6ff:fe9c:a8fb
fe80::21f:c6ff:fe9c:a8fb
```

The second last address is the one defined by my prefix + mac address. 

The IP addresses above are the ones that the system took as part of the privacy extensions for IPv6, and thus shouldn't be used for incoming connections.

Adding the search for `noprefixroute` solves this.