### PR TITLE
noprefixroute sits in $6

### DIFF
--- a/root/app/cloudflare-ddns.sh
+++ b/root/app/cloudflare-ddns.sh
@@ -156,7 +156,7 @@ while true; do
             ;;
         local:*)
             [[ ${CHECK_IPV4} == "true" ]] && newipv4=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet" {gsub(/\/.*$/, "", $2); print $2}' | head -1)
-            [[ ${CHECK_IPV6} == "true" ]] && newipv6=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet6" && $7 == "noprefixroute" {gsub(/\/.*$/, "", $2); print $2 }' | head -1)
+            [[ ${CHECK_IPV6} == "true" ]] && newipv6=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet6" && $6 == "noprefixroute" {gsub(/\/.*$/, "", $2); print $2 }' | head -1)
             ;;
     esac
     [[ ${CHECK_IPV4} == "true" ]] && logger "IPv4 detected by [${DETECTION_MODE}] is [${newipv4}]."


### PR DESCRIPTION
```bash
bash-5.1# ip addr show eno1| awk '$1 == "inet6" && $7 == "noprefixroute" {gsub(/\/.*$/, "", $2); print $2 }' | head -1
bash-5.1# # NOTHING
bash-5.1# ip addr show eno1| awk '$1 == "inet6" && $6 == "noprefixroute" {gsub(/\/.*$/, "", $2); print $2 }' | head -1
26**:****:****:****:****:****:****:**** # BINGO
```
