### PR TITLE
Ignore spaces in configuration

### DIFF
--- a/root/app/cloudflare-ddns.sh
+++ b/root/app/cloudflare-ddns.sh
@@ -94,11 +94,40 @@ LOG_LEVEL="${LOG_LEVEL:-3}"
 # READ IN VALUES
 DEFAULTIFS="${IFS}"
 IFS=';'
-read -r -a cfhost      <<< "${CF_HOSTS}"
-read -r -a cfzone      <<< "${CF_ZONES}"
-read -r -a cftype      <<< "${CF_RECORDTYPES}"
-read -r -a apprise_uri <<< "${APPRISE}"
+read -r -a cfhost_old      <<< "${CF_HOSTS}"
+read -r -a cfzone_old      <<< "${CF_ZONES}"
+read -r -a cftype_old      <<< "${CF_RECORDTYPES}"
+read -r -a apprise_uri_old <<< "${APPRISE}"
 IFS="${DEFAULTIFS}"
+
+VALUE_SEPARATOR_RE=$'[[:space:]]*;[[:space:]]*'
+IFS=$'\n' read -r -d '' -a cfhost < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${CF_HOSTS}")
+
+for i in "${!cfhost_old[@]}"; do 
+  printf "%s\t%s\n" "$i" "'${cfhost_old[$i]}'"
+  printf "%s\t%s\n" "$i" "'${cfhost[$i]}'"
+done
+
+IFS=$'\n' read -r -d '' -a cfzone < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${CF_ZONES}")
+
+for i in "${!cfzone_old[@]}"; do 
+  printf "%s\t%s\n" "$i" "'${cfzone_old[$i]}'"
+  printf "%s\t%s\n" "$i" "'${cfzone[$i]}'"
+done
+
+IFS=$'\n' read -r -d '' -a cftype < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${CF_RECORDTYPES}")
+
+for i in "${!cftype_old[@]}"; do 
+  printf "%s\t%s\n" "$i" "'${cftype_old[$i]}'"
+  printf "%s\t%s\n" "$i" "'${cftype[$i]}'"
+done
+
+IFS=$'\n' read -r -d '' -a apprise_uri < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${APPRISE}")
+
+for i in "${!apprise_uri_old[@]}"; do 
+  printf "%s\t%s\n" "$i" "'${apprise_uri_old[$i]}'"
+  printf "%s\t%s\n" "$i" "'${apprise_uri[$i]}'"
+done
 
 # SETUP CACHE
 cache_location="${1:-/dev/shm}"

--- a/root/app/cloudflare-ddns.sh
+++ b/root/app/cloudflare-ddns.sh
@@ -92,42 +92,12 @@ DETECTION_MODE="${DETECTION_MODE:-dig-whoami.cloudflare}"
 LOG_LEVEL="${LOG_LEVEL:-3}"
 
 # READ IN VALUES
-DEFAULTIFS="${IFS}"
-IFS=';'
-read -r -a cfhost_old      <<< "${CF_HOSTS}"
-read -r -a cfzone_old      <<< "${CF_ZONES}"
-read -r -a cftype_old      <<< "${CF_RECORDTYPES}"
-read -r -a apprise_uri_old <<< "${APPRISE}"
-IFS="${DEFAULTIFS}"
-
 VALUE_SEPARATOR_RE=$'[[:space:]]*;[[:space:]]*'
 IFS=$'\n' read -r -d '' -a cfhost < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${CF_HOSTS}")
-
-for i in "${!cfhost_old[@]}"; do 
-  printf "%s\t%s\n" "$i" "'${cfhost_old[$i]}'"
-  printf "%s\t%s\n" "$i" "'${cfhost[$i]}'"
-done
-
 IFS=$'\n' read -r -d '' -a cfzone < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${CF_ZONES}")
-
-for i in "${!cfzone_old[@]}"; do 
-  printf "%s\t%s\n" "$i" "'${cfzone_old[$i]}'"
-  printf "%s\t%s\n" "$i" "'${cfzone[$i]}'"
-done
-
 IFS=$'\n' read -r -d '' -a cftype < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${CF_RECORDTYPES}")
-
-for i in "${!cftype_old[@]}"; do 
-  printf "%s\t%s\n" "$i" "'${cftype_old[$i]}'"
-  printf "%s\t%s\n" "$i" "'${cftype[$i]}'"
-done
-
 IFS=$'\n' read -r -d '' -a apprise_uri < <(awk -F${VALUE_SEPARATOR_RE} '{ for( i=1; i<=NF; i++ ) print $i }' <<<"${APPRISE}")
-
-for i in "${!apprise_uri_old[@]}"; do 
-  printf "%s\t%s\n" "$i" "'${apprise_uri_old[$i]}'"
-  printf "%s\t%s\n" "$i" "'${apprise_uri[$i]}'"
-done
+unset VALUE_SEPARATOR_RE
 
 # SETUP CACHE
 cache_location="${1:-/dev/shm}"


### PR DESCRIPTION
When passing configuration arrays such as `CF_HOSTS` to `cloudflare-ddns.sh`, spaces around the delimiter (` ; `) are incorporated into the array values. 

This leads to a general error message that fails to point to the root cause (see attached log file [problem-log.txt](https://github.com/hotio/cloudflareddns/files/9175988/problem-log.txt)).

In the example, the problem ist that I specified 
```
CF_HOSTS='host.example.com; host.example.net'
CF_ZONES='<CF_ZONE_ID_example.com>; <CF_ZONE_ID_example.net>'
```

(note the space after `;`) instead of

```
CF_HOSTS='host.example.com;host.example.net'
CF_ZONES='<CF_ZONE_ID_example.com>;<CF_ZONE_ID_example.net>'
```

The proposed code change addresses this by having awk parse the values in the configuration and splitting them based on a regular expression that ignores white space.

[problem-log.txt](https://github.com/hotio/cloudflareddns/files/9175988/problem-log.txt)