### PR TITLE
Add curl-ipw.cn

### DIFF
--- a/root/app/cloudflare-ddns.sh
+++ b/root/app/cloudflare-ddns.sh
@@ -153,6 +153,10 @@ while true; do
             [[ ${CHECK_IPV4} == "true" ]] && newipv4=$(curl -fsL -4 ifconfig.co)
             [[ ${CHECK_IPV6} == "true" ]] && newipv6=$(curl -fsL -6 ifconfig.co)
             ;;
+        curl-ipw.cn)
+            [[ ${CHECK_IPV4} == "true" ]] && newipv4=$(curl -fsL -4 4.ipw.cn)
+            [[ ${CHECK_IPV6} == "true" ]] && newipv6=$(curl -fsL -6 6.ipw.cn)
+            ;;
         local:*)
             [[ ${CHECK_IPV4} == "true" ]] && newipv4=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet" {gsub(/\/.*$/, "", $2); print $2}' | head -1)
             [[ ${CHECK_IPV6} == "true" ]] && newipv6=$(ip addr show "${DETECTION_MODE/local:/}" 2>/dev/null | awk '$1 == "inet6" && $6 == "noprefixroute" {gsub(/\/.*$/, "", $2); print $2 }' | head -1)


### PR DESCRIPTION
Querying IP addresses with existing detection modes might be troublesome (slow / service not available / proxy IP prefered / etc.) in mainland China especially for IPv6. Therefore I added curl-ipw.cn whose server located in China as an alternative.

(Please feel free to correct me if I'm doing something wrong since it is almost my first time to raise a PR in others' repository.)